### PR TITLE
Add further autoload file to fix examples

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
             "Amp\\Parallel\\": "lib"
         },
         "files": [
-            "lib/Worker/functions.php"
+            "lib/Worker/functions.php",
+	    "examples/BlockingTask.php"
         ]
     },
     "autoload-dev": {


### PR DESCRIPTION
Without this addition the examples failed with "Uncaught Error: Class 'Amp\Parallel\Example\BlockingTask' not found" because this class are not loaded.