### PR TITLE
Fix typo in autoload-dev to load required class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Amp\\Parallel\\Example\\": "example",
+            "Amp\\Parallel\\Example\\": "examples",
             "Amp\\Parallel\\Test\\": "test"
         }
     }


### PR DESCRIPTION
I have looked again at PR #17 and the solution was quite easier. 
It was just a typo in the autoload-dev section.
