### PR TITLE
Fixes the constant used

### DIFF
--- a/lib/Process/ChannelledProcess.php
+++ b/lib/Process/ChannelledProcess.php
@@ -37,7 +37,7 @@ class ChannelledProcess implements ProcessContext, Strand {
         ];
 
         $options = (\PHP_SAPI === "phpdbg" ? " -b -qrr " : " ") . $this->formatOptions($options);
-        $separator = \PHP_BINARY === "phpdbg" ? " -- " : " ";
+        $separator = \PHP_SAPI === "phpdbg" ? " -- " : " ";
         $command = \escapeshellarg(\PHP_BINARY) . $options . $separator . \escapeshellarg($path);
 
         $processOptions = [];


### PR DESCRIPTION
`\PHP_BINARY` will never give phpdbg, but always the full path to the
binary. You meant to use `\PHP_SAPI` here too just like on the previous
line.