### PR TITLE
add the ability to set the cli binary for processes

### DIFF
--- a/lib/Process/ChannelledProcess.php
+++ b/lib/Process/ChannelledProcess.php
@@ -43,9 +43,11 @@ class ChannelledProcess implements ProcessContext, Strand {
             $script = \escapeshellarg($script);
         }
 
+        // use cli binary, if provided
+        $binary = defined('PHP_CLI_BINARY') ? \PHP_CLI_BINARY : \PHP_BINARY;
         $options = (\PHP_SAPI === "phpdbg" ? " -b -qrr " : " ") . $this->formatOptions($options);
         $separator = \PHP_SAPI === "phpdbg" ? " -- " : " ";
-        $command = \escapeshellarg(\PHP_BINARY) . $options . $separator . $script;
+        $command = \escapeshellarg($binary) . $options . $separator . $script;
 
         $processOptions = [];
 


### PR DESCRIPTION
This pull requests relates to issue https://github.com/amphp/parallel/issues/26

The feature can be used for example to create processes in a php-fpm context, if a php cli executable is also available. Just add defined('PHP_CLI_BINARY') || define('PHP_CLI_BINARY', '/usr/local/bin/php'); before your loop.