### PR TITLE
Avoid cyclic references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,12 @@ install:
   - chmod +x coveralls.phar
 
 script:
-  - phpdbg -qrr vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml
+    # phpdbg prints out of memory with pthreads enabled
+  - if [ "$TRAVIS_PHP_VERSION" = "7.0" ] || [ "$TRAVIS_PHP_VERSION" = "7.1" ]; then
+      phpdbg -qrr vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml;
+    else
+      vendor/bin/phpunit;
+    fi
   - PHP_CS_FIXER_IGNORE_ENV=1 php vendor/bin/php-cs-fixer --diff --dry-run -v fix
 
 after_script:

--- a/lib/Context/Process.php
+++ b/lib/Context/Process.php
@@ -122,7 +122,7 @@ class Process implements Context {
         $childStderr = $this->process->getStderr();
         $childStderr->unreference();
 
-        asyncCall(function () use ($childStderr) {
+        asyncCall(static function () use ($childStderr) {
             $stderr = new ByteStream\ResourceOutputStream(\STDERR);
             yield ByteStream\pipe($childStderr, $stderr);
         });

--- a/lib/Worker/DefaultPool.php
+++ b/lib/Worker/DefaultPool.php
@@ -61,11 +61,11 @@ class DefaultPool implements Pool {
         $this->idleWorkers = new \SplQueue;
         $this->busyQueue = new \SplQueue;
 
-        $workers = &$this->workers;
-        $idleWorkers = &$this->idleWorkers;
-        $busyQueue = &$this->busyQueue;
+        $workers = $this->workers;
+        $idleWorkers = $this->idleWorkers;
+        $busyQueue = $this->busyQueue;
 
-        $this->push = static function (Worker $worker) use (&$workers, &$idleWorkers, &$busyQueue) {
+        $this->push = static function (Worker $worker) use ($workers, $idleWorkers, $busyQueue) {
             \assert($workers->contains($worker), "The provided worker was not part of this queue");
 
             if (($workers[$worker] -= 1) === 0) {

--- a/test/Worker/AbstractPoolTest.php
+++ b/test/Worker/AbstractPoolTest.php
@@ -130,4 +130,24 @@ abstract class AbstractPoolTest extends TestCase {
             yield $pool->shutdown();
         });
     }
+
+    public function testCleanGarbageCollection() {
+        // See https://github.com/amphp/parallel-functions/issues/5
+        Loop::run(function () {
+            for ($i = 0; $i < 15; $i++) {
+                $pool = $this->createPool(32);
+
+                $values = \range(1, 50);
+                $tasks = \array_map(function (int $value): Task {
+                    return new TestTask($value);
+                }, $values);
+
+                $promises = \array_map(function (Task $task) use ($pool): Promise {
+                    return $pool->enqueue($task);
+                }, $tasks);
+
+                $this->assertSame($values, yield $promises);
+            }
+        });
+    }
 }


### PR DESCRIPTION
This ensures a clean garbage collection even without `shutdown` of the pool.

Fixes amphp/parallel-functions#5.