### PR TITLE
Escape script path in Process command

### DIFF
--- a/lib/Context/Process.php
+++ b/lib/Context/Process.php
@@ -98,7 +98,7 @@ class Process implements Context {
         $command = \implode(" ", [
             \escapeshellarg($binary),
             $this->formatOptions($options),
-            $scriptPath,
+            \escapeshellarg($scriptPath),
             $script,
         ]);
 


### PR DESCRIPTION
Fixes an issue I just encountered in amp/dns where a number of tests were failing because workers were failing to start, because the path of my checkout has a space in it.

Note also that the test suite is hanging for me on PHP7.2/Win64 (at `testCleanGarbageCollection()`), I don't have time to debug this at the moment. Appveyor looks like it's hanging in the same place.