### PR TITLE
Add PHP versions as a required dependency, and remove platform config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         }
     ],
     "require": {
+        "php": "^7",
         "amphp/amp": "^2",
         "amphp/byte-stream": "^1.2",
         "amphp/parser": "^1",
@@ -47,11 +48,6 @@
         "psr-4": {
             "Amp\\Parallel\\Example\\": "examples",
             "Amp\\Parallel\\Test\\": "test"
-        }
-    },
-    "config": {
-        "platform": {
-            "php": "7.0.0"
         }
     }
 }


### PR DESCRIPTION
IMHO this is an easier way to require PHP :)