### PR TITLE
Use the current config

### DIFF
--- a/lib/Context/Process.php
+++ b/lib/Context/Process.php
@@ -120,7 +120,7 @@ class Process implements Context {
 
         $command = \implode(" ", [
             \escapeshellarg($binary),
-            $phpConfig ? \escapeshellarg("-n -c $phpConfig") : "",
+            $phpConfig ? "-n -c ".\escapeshellarg($phpConfig) : "",
             $this->formatOptions($options),
             \escapeshellarg($scriptPath),
             $script,

--- a/lib/Context/Process.php
+++ b/lib/Context/Process.php
@@ -116,8 +116,11 @@ class Process implements Context {
             $script = \escapeshellarg($script);
         }
 
+        $phpConfig = \get_cfg_var('cfg_file_path');
+
         $command = \implode(" ", [
             \escapeshellarg($binary),
+            $phpConfig ? "-c $phpConfig" : "",
             $this->formatOptions($options),
             \escapeshellarg($scriptPath),
             $script,

--- a/lib/Context/Process.php
+++ b/lib/Context/Process.php
@@ -120,7 +120,7 @@ class Process implements Context {
 
         $command = \implode(" ", [
             \escapeshellarg($binary),
-            $phpConfig ? "-n -c $phpConfig" : "",
+            $phpConfig ? \escapeshellarg("-n -c $phpConfig") : "",
             $this->formatOptions($options),
             \escapeshellarg($scriptPath),
             $script,

--- a/lib/Context/Process.php
+++ b/lib/Context/Process.php
@@ -120,7 +120,7 @@ class Process implements Context {
 
         $command = \implode(" ", [
             \escapeshellarg($binary),
-            $phpConfig ? "-c $phpConfig" : "",
+            $phpConfig ? "-n -c $phpConfig" : "",
             $this->formatOptions($options),
             \escapeshellarg($scriptPath),
             $script,


### PR DESCRIPTION
In the case of [Box](https://github.com/humbug/box) for example, the PHP process may be restarted (via [composer/xdebug-handler](https://github.com/composer/xdebug-handler)) with a different configuration file to disable xdebug among other things. Right now, it looks like the processes used are not using that configuration and as a result, even though the main process may not have xdebug enabled, the works will run with xdebug enabled.

It seems however that my patch is incomplete as it looks like some elements of the config are loaded twice, the following message is printed at the start of each worker:

```
PHP Warning:  Module 'sodium' already loaded in Unknown on line 0
```