### PR TITLE
Fixed typo in exception message

### DIFF
--- a/lib/Context/Process.php
+++ b/lib/Context/Process.php
@@ -194,7 +194,7 @@ final class Process implements Context
                 return $pid;
             } catch (\Throwable $exception) {
                 $this->process->kill();
-                throw new ContextException("Staring the process failed", 0, $exception);
+                throw new ContextException("Starting the process failed", 0, $exception);
             }
         });
     }


### PR DESCRIPTION
When the process cannot be started it tells me "Staring the process failed".

You can stare at a process all you want, but it should be "Starting".