### PR TITLE
Fixed examples

### DIFF
--- a/examples/worker-pool.php
+++ b/examples/worker-pool.php
@@ -28,11 +28,10 @@ Loop::run(function () use (&$results, $tasks) {
 
     $coroutines = [];
 
-    foreach ($tasks as $task) {
-        $coroutines[] = Amp\call(function () use ($pool, $task) {
+    foreach ($tasks as $index => $task) {
+        $coroutines[] = Amp\call(function () use ($pool, $index, $task) {
             $result = yield $pool->enqueue($task);
-            $url = $task->getArgs()[0];
-            \printf("\nRead from %s: %d bytes\n", $url, \strlen($result));
+            \printf("\nRead from task %d: %d bytes\n", $index, \strlen($result));
             return $result;
         });
     }

--- a/examples/worker-pool.php
+++ b/examples/worker-pool.php
@@ -12,9 +12,9 @@ $results = [];
 
 // We can first define tasks and then run them
 $tasks = [
-    new CallableTask('file_get_contents', 'http://php.net'),
-    new CallableTask('file_get_contents', 'https://amphp.org'),
-    new CallableTask('file_get_contents', 'https://github.com'),
+    new CallableTask('file_get_contents', ['http://php.net']),
+    new CallableTask('file_get_contents', ['https://amphp.org']),
+    new CallableTask('file_get_contents', ['https://github.com']),
 ];
 
 // Event loop for parallel tasks

--- a/examples/worker.php
+++ b/examples/worker.php
@@ -10,7 +10,7 @@ Amp\Loop::run(function () {
 
     $worker = $factory->create();
 
-    $result = yield $worker->enqueue(new CallableTask('file_get_contents', 'https://google.com'));
+    $result = yield $worker->enqueue(new CallableTask('file_get_contents', ['https://google.com']));
     \printf("Read %d bytes\n", \strlen($result));
 
     $code = yield $worker->shutdown();


### PR DESCRIPTION
`CallableTask` expects the parameters to be passed in as an array