### PR TITLE
Revert #91

### DIFF
--- a/docs/workers.md
+++ b/docs/workers.md
@@ -97,7 +97,7 @@ Additionally `Environment` allows setting a TTL for entries, so can be used as a
 
 namespace Amp\Parallel\Worker;
 
-interface Environment implements \ArrayAccess
+interface Environment extends \ArrayAccess
 {
     /**
      * @param string $key


### PR DESCRIPTION
Sorry... I just realized that the change was wrong. Since Environment is also an interface and not a class, extends was actually correct there.