### PR TITLE
Check if process is running before killing on start-up failure

### DIFF
--- a/lib/Context/Process.php
+++ b/lib/Context/Process.php
@@ -194,7 +194,9 @@ final class Process implements Context
 
                 return $pid;
             } catch (\Throwable $exception) {
-                $this->process->kill();
+                if ($this->isRunning()) {
+                    $this->kill();
+                }
                 throw new ContextException("Starting the process failed", 0, $exception);
             }
         });


### PR DESCRIPTION
We ran into this issue in production. I originally fixed it with the following snippet.

```php
try {
    $process->kill();
} (Throwable $e) {
    // ignore silently if killing failed
}
```

This is more robust than the proposed change, but it the PR should suffice and it's the same solution as in `::join()`.

A tag after merge would be appreciated so I can get rid of this manual bugfix.