### PR TITLE
Fix typos in documentation examples

### DIFF
--- a/docs/processes.md
+++ b/docs/processes.md
@@ -42,7 +42,7 @@ Loop::run(function () {
 
     yield $context->send($url);
 
-    $requestData = yield $process->receive();
+    $requestData = yield $context->receive();
 
     printf("Received %d bytes from %s\n", \strlen($requestData), $url);
 

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -21,7 +21,7 @@ return function (Channel $channel): \Generator {
     yield $channel->send($data);
 
     return 'Any serializable data';
-});
+};
 ```
 
 ## Parent Process


### PR DESCRIPTION
This PR fixes 2 typos on the processes and threads example.

 - The child process snippet had an extra closing parathesis.
 - The parent process referenced an undefined variable.