### PR TITLE
Replace Artax with http-client

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ foreach ($responses as $url => $response) {
 ```
 
 [`file_get_contents`](https://secure.php.net/file_get_contents) is just used as an example for a blocking function here.
-If you just want to fetch multiple HTTP resources concurrently, it's better to use [Artax](https://amphp.org/artax/), our non-blocking HTTP client.
+If you just want to fetch multiple HTTP resources concurrently, it's better to use [http-client](https://amphp.org/http-client/), our non-blocking HTTP client.
 
 The functions you call must be predefined or autoloadable by Composer so they also exist in the worker processes.
 Instead of simple callables, you can also [enqueue `Task` instances](./workers#task) with `Amp\Parallel\Worker\enqueue()`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ foreach ($responses as $url => $response) {
 ```
 
 [`file_get_contents`](https://secure.php.net/file_get_contents) is just used as an example for a blocking function here.
-If you just want to fetch multiple HTTP resources concurrently, it's better to use [http-client](https://amphp.org/http-client/), our non-blocking HTTP client.
+If you just want to fetch multiple HTTP resources concurrently, it's better to use [`amphp/http-client`](https://amphp.org/http-client/), our non-blocking HTTP client.
 
 The functions you call must be predefined or autoloadable by Composer so they also exist in the worker processes.
 Instead of simple callables, you can also [enqueue `Task` instances](./workers#task) with `Amp\Parallel\Worker\enqueue()`.


### PR DESCRIPTION
Looks like Artax is replaced by http-client package. But in the docs it still refers to Artax, this PR fixes this.