### PR TITLE
Do not re-alias SerializationException

### DIFF
--- a/lib/Sync/functions.php
+++ b/lib/Sync/functions.php
@@ -4,8 +4,10 @@ namespace Amp\Parallel\Sync;
 
 use Amp\Serialization\SerializationException as SerializerException;
 
-// Alias must be defined in an always-loaded file as catch blocks do not trigger the autoloader.
-\class_alias(SerializerException::class, SerializationException::class);
+if (!\class_exists(SerializationException::class)) {
+    // Alias must be defined in an always-loaded file as catch blocks do not trigger the autoloader.
+    \class_alias(SerializerException::class, SerializationException::class);
+}
 
 /**
  * @param \Throwable $exception


### PR DESCRIPTION
Useful to avoid warnings when preloading classes using opcache.